### PR TITLE
slim.losses to tf.losses

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_9" default="false" project-jdk-name="Python 3.6.2 (~/Frameworks/miniconda3/envs/py36/bin/python)" project-jdk-type="Python SDK" />
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/model.py
+++ b/model.py
@@ -110,8 +110,8 @@ class DTN(object):
             self.fgfx = self.content_extractor(self.fake_images, reuse=True)
 
             # loss
-            self.d_loss_src = slim.losses.sigmoid_cross_entropy(self.logits, tf.zeros_like(self.logits))
-            self.g_loss_src = slim.losses.sigmoid_cross_entropy(self.logits, tf.ones_like(self.logits))
+            self.d_loss_src = tf.losses.sigmoid_cross_entropy(self.logits, tf.zeros_like(self.logits))
+            self.g_loss_src = tf.losses.sigmoid_cross_entropy(self.logits, tf.ones_like(self.logits))
             self.f_loss_src = tf.reduce_mean(tf.square(self.fx - self.fgfx)) * 15.0
             
             # optimizer
@@ -147,10 +147,10 @@ class DTN(object):
             self.logits_real = self.discriminator(self.trg_images, reuse=True)
             
             # loss
-            self.d_loss_fake_trg = slim.losses.sigmoid_cross_entropy(self.logits_fake, tf.zeros_like(self.logits_fake))
-            self.d_loss_real_trg = slim.losses.sigmoid_cross_entropy(self.logits_real, tf.ones_like(self.logits_real))
+            self.d_loss_fake_trg = tf.losses.sigmoid_cross_entropy(self.logits_fake, tf.zeros_like(self.logits_fake))
+            self.d_loss_real_trg = tf.losses.sigmoid_cross_entropy(self.logits_real, tf.ones_like(self.logits_real))
             self.d_loss_trg = self.d_loss_fake_trg + self.d_loss_real_trg
-            self.g_loss_fake_trg = slim.losses.sigmoid_cross_entropy(self.logits_fake, tf.ones_like(self.logits_fake))
+            self.g_loss_fake_trg = tf.losses.sigmoid_cross_entropy(self.logits_fake, tf.ones_like(self.logits_fake))
             self.g_loss_const_trg = tf.reduce_mean(tf.square(self.trg_images - self.reconst_images)) * 15.0
             self.g_loss_trg = self.g_loss_fake_trg + self.g_loss_const_trg
             

--- a/model.py
+++ b/model.py
@@ -125,7 +125,7 @@ class DTN(object):
             f_vars = [var for var in t_vars if 'content_extractor' in var.name]
             
             # train op
-            with tf.name_scope('source_train_op'):
+            with tf.name_scope('source_train_op', reuse=False):
                 self.d_train_op_src = slim.learning.create_train_op(self.d_loss_src, self.d_optimizer_src, variables_to_train=d_vars)
                 self.g_train_op_src = slim.learning.create_train_op(self.g_loss_src, self.g_optimizer_src, variables_to_train=g_vars)
                 self.f_train_op_src = slim.learning.create_train_op(self.f_loss_src, self.f_optimizer_src, variables_to_train=f_vars)
@@ -159,7 +159,7 @@ class DTN(object):
             self.g_optimizer_trg = tf.train.AdamOptimizer(self.learning_rate)
 
             # train op
-            with tf.name_scope('target_train_op'):
+            with tf.name_scope('target_train_op', reuse=False):
                 self.d_train_op_trg = slim.learning.create_train_op(self.d_loss_trg, self.d_optimizer_trg, variables_to_train=d_vars)
                 self.g_train_op_trg = slim.learning.create_train_op(self.g_loss_trg, self.g_optimizer_trg, variables_to_train=g_vars)
             

--- a/model.py
+++ b/model.py
@@ -83,7 +83,7 @@ class DTN(object):
             self.accuracy = tf.reduce_mean(tf.cast(self.correct_pred, tf.float32))
 
             # loss and train op
-            self.loss = slim.losses.sparse_softmax_cross_entropy(self.logits, self.labels)
+            self.loss = tf.losses.sparse_softmax_cross_entropy(self.logits, self.labels)
             self.optimizer = tf.train.AdamOptimizer(self.learning_rate) 
             self.train_op = slim.learning.create_train_op(self.loss, self.optimizer)
             


### PR DESCRIPTION
 As mentioned [here](https://github.com/tensorflow/tensorflow/blob/5747ec38cf9ffaa586b854910af8b57e148e9543/tensorflow/contrib/losses/python/losses/loss_ops.py#L302), slim.losses.sigmoid_cross_entropy is deprecated from 2016-12-30, and slim.losses.sparse_softmax_cross_entropy_with_logits is deprecated as mentioned [here](https://github.com/tensorflow/tensorflow/blob/5747ec38cf9ffaa586b854910af8b57e148e9543/tensorflow/contrib/losses/python/losses/loss_ops.py#L401)